### PR TITLE
Fix input background color on dark mode

### DIFF
--- a/extension/content-scripts/goal-prompt/goal-prompt.scss
+++ b/extension/content-scripts/goal-prompt/goal-prompt.scss
@@ -54,6 +54,7 @@
       padding-left: 15px;
       margin: 0;
       margin-right: 15px;
+      background-color: white;
 
       border-radius: 9px;
       border: 2px solid rgb(235, 235, 235);


### PR DESCRIPTION
Previously, when dark mode was activated, the input background color matched the text color. This change ensures they are distinct for better readability.